### PR TITLE
Use base-certificate Secret for TLS in Ingress

### DIFF
--- a/kubernetes/kubernetes.libsonnet
+++ b/kubernetes/kubernetes.libsonnet
@@ -89,7 +89,6 @@ local ingressSpec(ingressConfig, serviceObject) =
   ingress.new(name=serviceObject.metadata.name)
   + ingress.mixin.metadata.withAnnotations(
     {
-      'cert-manager.io/cluster-issuer': certIssuer,
       'kubernetes.io/ingress.class': ingressClass,
       'letsbuild.com/public': std.toString(isPublic),
     }
@@ -108,7 +107,7 @@ local ingressSpec(ingressConfig, serviceObject) =
     },
   ])
   + ingress.mixin.spec.withTls([
-    { hosts: [ingressConfig.host], secretName: '%s-ingress-tls' % serviceObject.metadata.name },
+    { hosts: [ingressConfig.host], secretName: 'base-certificate' },
   ]);
 
 local letsbuildServiceDeployment(deploymentConfig, withService=true, withIngress=false, withServiceAccountObject={}, ingressConfig={}) = {


### PR DESCRIPTION
With letsbuilders/letsbuild-argocd-apps#38 each environment gets a base certificate with wildcards. There is no longer a need to have per-ingress certificates.