### PR TITLE
Topology and architecture constraints

### DIFF
--- a/crossplane/aws-utils.libsonnet
+++ b/crossplane/aws-utils.libsonnet
@@ -36,12 +36,6 @@ local bucketPolicy = aws.s3.v1alpha3.bucketPolicy;
     accountName: c.aws.accountName,
     region: c.aws.region,
   },
-  
-  readOnlyBucketPolicyName:: '%(serviceName)s-readonly-%(bucketName)s' % {
-    serviceName: c.serviceName,
-    bucketName: s.bucketName,
-  },
-
   roleName:: '%(clusterName)s-%(namespace)s-%(serviceName)s' % {
     serviceName: c.serviceName,
     namespace: c.serviceNamespace,
@@ -106,28 +100,6 @@ local bucketPolicy = aws.s3.v1alpha3.bucketPolicy;
     ]
   },
 
-  readOnlyBucketPolicyDocument:: {
-    version: '2012-10-17',
-    statements: [
-      {
-        sid: 'DownloadOnly',
-        action: ['s3:GetObject', 's3:GetObjectVersion'],
-        effect: 'Allow',
-        resource: ['arn:aws:s3:::%s/*' % s.bucketName],
-        principal: {
-          awsPrincipals: [
-            {
-              // If I use iamRoleArnRef here tanka wants to remove iamRoleArn because it gets added by crossplane
-              // https://github.com/crossplane/provider-aws/issues/555
-              iamRoleArn: 'arn:aws:iam::%(accountId)s:role/%(roleName)s' % { accountId: c.aws.accountId, roleName: s.roleName },
-            },
-          ],
-        },
-      },
-    ]
-  },
-
-
   overrides:: {
     // service_account field overrides
     // service_account will be defined by https://github.com/grafana/jsonnet-libs/blob/master/ksonnet-util/util.libsonnet#L49
@@ -145,10 +117,6 @@ local bucketPolicy = aws.s3.v1alpha3.bucketPolicy;
 
   // Resources
 
-  readOnlyBucketPolicyResource::
-    bucketPolicy.new(name=s.readOnlyBucketPolicyName, bucketName=s.bucketName, region=c.aws.region, policy=s.readOnlyBucketPolicyDocument)
-    + bucketPolicy.mixin.spec.providerConfigRef.new(c.crossplaneProvider),
-    
   bucket:: {
     bucket:
       bucket.new(name=s.bucketName)

--- a/kubernetes/config-skeleton.libsonnet
+++ b/kubernetes/config-skeleton.libsonnet
@@ -89,11 +89,11 @@
         local cont = self,
 
         name: sts.name,
-      
+
         repository: error '_config.statefulSet.container.repository must be set',
         tag: error '_config.statefulSet.container.tag must be set',
         image: '%(repository)s:%(tag)s' % { repository: cont.repository, tag: cont.tag },
-        
+
         envVars: {
           ENVIRONMENT: s.namespace,
         },

--- a/kubernetes/init-containers.libsonnet
+++ b/kubernetes/init-containers.libsonnet
@@ -9,8 +9,8 @@ local waitForPostgres = function(secretName, timeout='300000') {
   name: 'wait-for-postgres',
   image: waitForPortImage,
   command: ['/usr/local/bin/wait-port', '--wait-for-dns', '-t', '3000', '$(PGHOST):$(PGPORT)'],
-   // PGHOST and PGPORT are stored in the secret
-  envFrom+: [ { secretRef: { name: secretName } } ]
+  // PGHOST and PGPORT are stored in the secret
+  envFrom+: [{ secretRef: { name: secretName } }],
 };
 
 local waitForKafka = function(timeout='300000') {
@@ -20,7 +20,7 @@ local waitForKafka = function(timeout='300000') {
   envVars: {
     // Kafka connection endpoint is the same for all environments
     KAFKA_SERVERS: 'kafka-kafka-brokers:9092',
-  }
+  },
 };
 
 local waitForSchemaRegistry = function(timeout='300000') {
@@ -30,7 +30,7 @@ local waitForSchemaRegistry = function(timeout='300000') {
   envVars: {
     // Schema Registry URL is the same for all environments
     KAFKA_SCHEMA_REGISTRY_URL: 'http://confluentic-cp-schema-registry:8081',
-  }
+  },
 };
 
 local waitForPort = function(timeout='300000', target) {

--- a/kubernetes/kubernetes.libsonnet
+++ b/kubernetes/kubernetes.libsonnet
@@ -134,6 +134,11 @@ local letsbuildServiceDeployment(deploymentConfig, withService=true, withIngress
     + deployment.mixin.spec.withRevisionHistoryLimit(
       if std.objectHas(dc, 'revisionHistoryLimit') then dc.revisionHistoryLimit else 3
     )
+    + deployment.mixin.spec.template.spec.withNodeSelector({
+      'kubernetes.io/os': 'linux',
+      'letsbuild.com/purpose': 'worker',
+      'kubernetes.io/arch': 'amd64',
+    })
     + (
       if std.length(withServiceAccountObject) > 0
       then
@@ -185,6 +190,11 @@ local letsbuildServiceStatefulSet(statefulsetConfig, withService=true) = {
       //      'sidecar.istio.io/proxyMemoryLimit': '',
       'argocd.argoproj.io/sync-wave': '1',
     })
+    + statefulSet.mixin.spec.template.spec.withNodeSelector({
+      'kubernetes.io/os': 'linux',
+      'letsbuild.com/purpose': 'worker',
+      'kubernetes.io/arch': 'amd64',
+    })
     + statefulSet.mixin.spec.template.spec.withInitContainers(initContainers)
     // Setting revisionHistoryLimit to clean up unused ReplicaSets
     + statefulSet.mixin.spec.withRevisionHistoryLimit(
@@ -220,6 +230,11 @@ local letsbuildJob(config, withServiceAccountObject={}) = {
     // Disable Istio sidecar to avoid never-ending Jobs
     + job.mixin.spec.template.metadata.withAnnotations({
       'sidecar.istio.io/inject': 'false',
+    })
+    + statefulSet.mixin.spec.template.spec.withNodeSelector({
+      'kubernetes.io/os': 'linux',
+      'letsbuild.com/purpose': 'worker',
+      'kubernetes.io/arch': 'amd64',
     })
     + job.mixin.spec.withBackoffLimit(0)
     + job.mixin.spec.withTtlSecondsAfterFinished(180)

--- a/kubernetes/kubernetes.libsonnet
+++ b/kubernetes/kubernetes.libsonnet
@@ -129,6 +129,25 @@ local letsbuildServiceDeployment(deploymentConfig, withService=true, withIngress
       //      'sidecar.istio.io/proxyMemoryLimit': '',
       'argocd.argoproj.io/sync-wave': '1',
     })
+    + deployment.mixin.spec.template.metadata.withLabels({
+      name: dc.name,
+      app: dc.name,
+      version: dc.container.tag,
+
+    })
+    + deployment.mixin.spec.template.spec.withTopologySpreadConstraints([
+      {
+        maxSkew: 1,
+        topologyKey: 'topology.kubernetes.io/zone',
+        whenUnsatisfiable: 'ScheduleAnyway',
+        labelSelector: {
+          matchLabels: {
+            app: dc.name,
+            version: dc.container.tag,
+          },
+        },
+      },
+    ])
     + deployment.mixin.spec.template.spec.withInitContainers(initContainers)
     // Setting revisionHistoryLimit to clean up unused ReplicaSets
     + deployment.mixin.spec.withRevisionHistoryLimit(

--- a/kubernetes/kubernetes.libsonnet
+++ b/kubernetes/kubernetes.libsonnet
@@ -250,7 +250,7 @@ local letsbuildJob(config, withServiceAccountObject={}) = {
     + job.mixin.spec.template.metadata.withAnnotations({
       'sidecar.istio.io/inject': 'false',
     })
-    + statefulSet.mixin.spec.template.spec.withNodeSelector({
+    + job.mixin.spec.template.spec.withNodeSelector({
       'kubernetes.io/os': 'linux',
       'letsbuild.com/purpose': 'worker',
       'kubernetes.io/arch': 'amd64',


### PR DESCRIPTION
Resolves https://github.com/letsbuilders/DevOps/issues/42
Resolves https://github.com/letsbuilders/DevOps/issues/40

* Adding `app` and `version` labels as recommended by [Istio](https://istio.io/latest/docs/ops/deployment/requirements/).
* Using `app` and `version` labels in pod topology constraints to assure that all pods using the same app version are spread across available topological zones.
* Using `ScheduleAnyway` strategy to avoid hard blocking pods from being scheduled. In case of uneven spread new pods will be scheduled on nodes that minimize the skew. 
* Adding `nodeSelector` with os and cpu architecture constraints. This will prevent unintentional scheduling of services not supporting ARMs. Note: we still need to adjust https://github.com/letsbuilders/letsbuild-kubernetes-integrations


This PR requires replacing legacy `ksonnet` lib with import `github.com/jsonnet-libs/k8s-libsonnet/1.20` because ksonnet does not support topology constraints. 
