### PR TITLE
Add an option to expose public API paths by teams

### DIFF
--- a/kubernetes/config-skeleton.libsonnet
+++ b/kubernetes/config-skeleton.libsonnet
@@ -4,6 +4,7 @@
 
     namespace: error '_config.namespace must be set',
     clusterDomain: error 'clusterDomain has to be set',
+    envDomain: '%(namespace)s.%(clusterDomain)s' % { namespace: s.namespace, clusterDomain: s.clusterDomain },
 
     deployment: {
       local depl = self,
@@ -118,6 +119,11 @@
     },
     ingress: {
       host: error '_config.ingress.host must be set',
+    },
+    publicAPI: {
+      host: 'api.%(envDomain)s' % { envDomain: s.envDomain },
+      name: s.deployment.name,
+      paths: ['/'],
     },
   },
 }


### PR DESCRIPTION
Resolves https://github.com/letsbuilders/DevOps/issues/53


To enable it teams would need to add the below changes to their jsonnet code (plus update the jsonnet library once I merge this PR):

```diff
@@ -22,6 +22,8 @@ local prometheusUtils = import 'github.com/letsbuilders/jsonnet-libs/kubernetes/
       deploymentConfig=c.deployment,
       withService=true,
       withIngress=false,
+      withPublicApi=true,
+      publicApiConfig=c.publicAPI,
       withServiceAccountObject=$.rbac.service_account,
     ),
   serviceMonitor: prometheusUtils.serviceMonitor
```

by default it will allow access to `/<service-name>/`

if teams need to narrow it down they can do so with

```diff
@@ -89,5 +89,8 @@ local envFromSecret = k.core.v1.container.envFromType.mixin.secretRef.withName;
         },
       },
     },
+    publicAPI+: {
+      paths: ['/some/path', '/some/other/path']
+    }
   },
 }

```

the library will always prefix those paths with the service name so the result will be `/<service-name>/some/path` and `/<service-name>/some/other/path`