### PR TITLE
Pass OTEL_RESOURCE_ATTRIBUTES to all LetsBuild pods

### DIFF
--- a/kubernetes/config-skeleton.libsonnet
+++ b/kubernetes/config-skeleton.libsonnet
@@ -34,9 +34,9 @@
             valueFrom: { fieldRef: { fieldPath: 'status.podIP' } },
           },
           {
-            name: 'CONTAINER_NAME',
-            value: cont.name,
-          },
+            name: 'OTEL_RESOURCE_ATTRIBUTES',
+            value: 'k8s.pod.ip=$(POD_IP),container=%s' % cont.name
+          }
         ],
         envFrom: [],
       },
@@ -73,9 +73,9 @@
             valueFrom: { fieldRef: { fieldPath: 'status.podIP' } },
           },
           {
-            name: 'CONTAINER_NAME',
-            value: cont.name,
-          },
+            name: 'OTEL_RESOURCE_ATTRIBUTES',
+            value: 'k8s.pod.ip=$(POD_IP),container=%s' % cont.name
+          }
         ],
         envFrom: [],
       },
@@ -108,9 +108,9 @@
             valueFrom: { fieldRef: { fieldPath: 'status.podIP' } },
           },
           {
-            name: 'CONTAINER_NAME',
-            value: cont.name,
-          },
+            name: 'OTEL_RESOURCE_ATTRIBUTES',
+            value: 'k8s.pod.ip=$(POD_IP),container=%s' % cont.name
+          }
         ],
         envFrom: [],
       },


### PR DESCRIPTION
Pass span attributes to opentelemetry SDKs containing information needed for Grafana's "logs for this span" feature to work

OTEL_RESOURCE_ATTRIBUTES defined in OpenTelemetry's spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/sdk.md#specifying-resource-information-via-an-environment-variable

we need to pass `k8s.pod.ip` so grafana agent knows which pod sent the span, and `container` so we can get logs for only matching containers and not sidecars (like istio-proxy) 

