### PR TITLE
Add tags and labels for kubecost

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,11 +24,18 @@ jobs:
       - run: |
           go install github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@latest
           go install github.com/grafana/tanka/cmd/tk@v0.20.0
+          go install github.com/yannh/kubeconform/cmd/kubeconform@latest
 
       # Install dependencies
       - run: ~/go/bin/jb install
         working-directory: ./tests/tanka
 
-      # Run tests
-      - run: ~/go/bin/tk eval environments/${{ matrix.testcase }} -V tag=test
+      # render manifests
+      - run:
+         ~/go/bin/tk show environments/${{ matrix.testcase }} --dangerous-allow-redirect -V tag=test > ${{ matrix.testcase }}.yaml
+        working-directory: ./tests/tanka
+
+      # validate manifests
+      - run:
+          ~/go/bin/kubeconform -kubernetes-version 1.21.0 -ignore-missing-schemas ${{ matrix.testcase }}.yaml
         working-directory: ./tests/tanka

--- a/kubernetes/config-skeleton.libsonnet
+++ b/kubernetes/config-skeleton.libsonnet
@@ -6,26 +6,32 @@
     clusterDomain: error 'clusterDomain has to be set',
     envDomain: '%(namespace)s.%(clusterDomain)s' % { namespace: s.namespace, clusterDomain: s.clusterDomain },
 
-    deployment: {
-      local depl = self,
+    common: {
+      // Shared settings between Deployment, StatefulSet and Job objects
+      local common = self,
 
-      name: error '_config.deployment.name must be set',
-
+      // Object labels
       labels: {},
+
+      // Object annotations
       annotations: {},
 
+      // Pod Labels
       podLabels: {
-        team: error '_config.deployment.podLabels.team must be set',
+        team: error 'podLabels.team must be set',
         dept: 'product',
         product: 'letsbuild',
         env: s.namespace,
       },
+
+      // Pod annotation
       podAnnotations: {},
 
+      // Main application containrt
       container: {
         local cont = self,
 
-        name: depl.name,
+        name: common.name,
         repository: error '_config.deployment.container.repository must be set',
         tag: error '_config.deployment.container.tag must be set',
         image: '%(repository)s:%(tag)s' % { repository: cont.repository, tag: cont.tag },
@@ -54,92 +60,31 @@
 
       sidecarContainers: [],
       initContainers: [],
+
     },
-    job: {
-      local job = self,
 
-      name: error '_config.job.name must be set',
+    deployment: s.common + {
+      local depl = self,
 
-      labels: {
-        team: error '_config.job.labels.team must be set',
-        dept: 'product',
-        product: 'letsbuild',
-        env: s.namespace,
-      },
-
-      container: {
-        local cont = self,
-
-        name: job.name,
-
-        repository: error '_config.job.container.repository must be set',
-        tag: error '_config.job.container.tag must be set',
-        image: '%(repository)s:%(tag)s' % { repository: cont.repository, tag: cont.tag },
-
-        imagePullPolicy: 'IfNotPresent',
-
-        envVars: {
-          ENVIRONMENT: s.namespace,
-        },
-        extraEnvVars: [
-          {
-            name: 'HOST_IP',
-            valueFrom: { fieldRef: { fieldPath: 'status.hostIP' } },
-          },
-          {
-            name: 'POD_IP',
-            valueFrom: { fieldRef: { fieldPath: 'status.podIP' } },
-          },
-          {
-            name: 'OTEL_RESOURCE_ATTRIBUTES',
-            value: 'k8s.pod.ip=$(POD_IP),container=%s' % cont.name,
-          },
-        ],
-        envFrom: [],
-      },
     },
-    statefulSet: {
-      local sts = self,
 
-      name: error '_config.statefulSet.name must be set',
-
-      labels: {
-        team: error '_config.statefulSet.labels.team must be set',
-        dept: 'product',
-        product: 'letsbuild',
-        env: s.namespace,
+    job: s.common + {
+      // overrides specific to Jobs
+      annotations+: {
+        // ArgoCD sync settings
+        'argocd.argoproj.io/hook': 'Sync',
+        'argocd.argoproj.io/hook-delete-policy': 'BeforeHookCreation',
+        'argocd.argoproj.io/sync-wave': '-1',
       },
+      podAnnotations+: {
+        'sidecar.istio.io/inject': 'false',
+        'sidecar.istio.io/proxyCPU':: null,
+        'sidecar.istio.io/proxyMemory':: null,
+      }
 
-      container: {
-        local cont = self,
-
-        name: sts.name,
-
-        repository: error '_config.statefulSet.container.repository must be set',
-        tag: error '_config.statefulSet.container.tag must be set',
-        image: '%(repository)s:%(tag)s' % { repository: cont.repository, tag: cont.tag },
-
-        envVars: {
-          ENVIRONMENT: s.namespace,
-        },
-        extraEnvVars: [
-          {
-            name: 'HOST_IP',
-            valueFrom: { fieldRef: { fieldPath: 'status.hostIP' } },
-          },
-          {
-            name: 'POD_IP',
-            valueFrom: { fieldRef: { fieldPath: 'status.podIP' } },
-          },
-          {
-            name: 'OTEL_RESOURCE_ATTRIBUTES',
-            value: 'k8s.pod.ip=$(POD_IP),container=%s' % cont.name,
-          },
-        ],
-        envFrom: [],
-      },
-      sidecarContainers: [],
-      initContainers: [],
+    },
+    statefulSet: s.common + {
+      // overrides specific to statefulsets
     },
     ingress: {
       host: error '_config.ingress.host must be set',

--- a/kubernetes/config-skeleton.libsonnet
+++ b/kubernetes/config-skeleton.libsonnet
@@ -11,6 +11,17 @@
 
       name: error '_config.deployment.name must be set',
 
+      labels: {},
+      annotations: {},
+
+      podLabels: {
+        team: error '_config.deployment.podLabels.team must be set',
+        dept: 'product',
+        product: 'letsbuild',
+        env: s.namespace,
+      },
+      podAnnotations: {},
+
       container: {
         local cont = self,
 
@@ -35,8 +46,8 @@
           },
           {
             name: 'OTEL_RESOURCE_ATTRIBUTES',
-            value: 'k8s.pod.ip=$(POD_IP),container=%s' % cont.name
-          }
+            value: 'k8s.pod.ip=$(POD_IP),container=%s' % cont.name,
+          },
         ],
         envFrom: [],
       },
@@ -48,6 +59,13 @@
       local job = self,
 
       name: error '_config.job.name must be set',
+
+      labels: {
+        team: error '_config.job.labels.team must be set',
+        dept: 'product',
+        product: 'letsbuild',
+        env: s.namespace,
+      },
 
       container: {
         local cont = self,
@@ -74,8 +92,8 @@
           },
           {
             name: 'OTEL_RESOURCE_ATTRIBUTES',
-            value: 'k8s.pod.ip=$(POD_IP),container=%s' % cont.name
-          }
+            value: 'k8s.pod.ip=$(POD_IP),container=%s' % cont.name,
+          },
         ],
         envFrom: [],
       },
@@ -85,6 +103,12 @@
 
       name: error '_config.statefulSet.name must be set',
 
+      labels: {
+        team: error '_config.statefulSet.labels.team must be set',
+        dept: 'product',
+        product: 'letsbuild',
+        env: s.namespace,
+      },
 
       container: {
         local cont = self,
@@ -109,8 +133,8 @@
           },
           {
             name: 'OTEL_RESOURCE_ATTRIBUTES',
-            value: 'k8s.pod.ip=$(POD_IP),container=%s' % cont.name
-          }
+            value: 'k8s.pod.ip=$(POD_IP),container=%s' % cont.name,
+          },
         ],
         envFrom: [],
       },

--- a/tests/tanka/environments/aws/main.jsonnet
+++ b/tests/tanka/environments/aws/main.jsonnet
@@ -28,6 +28,7 @@ function(namespace='test') {
   // Assertions
   assert std.objectHas(self.data.aws, 'bucket'),
   assert std.isObject(self.data.aws.bucket.bucket),
+  assert std.isArray(self.data.aws.bucket.bucket.spec.forProvider.tagging.tagSet),
   assert std.isObject(self.data.aws.bucket.bucketPolicy),
 
 }

--- a/tests/tanka/lib/letsbuilders/config.libsonnet
+++ b/tests/tanka/lib/letsbuilders/config.libsonnet
@@ -44,6 +44,33 @@ local lbInitContainers = import 'kubernetes/init-containers.libsonnet';
         },
       ],
     },
+
+    statefulSet+: {
+      name: 'test',
+      podLabels+: {
+        team: 'devops'
+      },
+      container+: {
+        // Main application
+        name: 'test',
+
+        repository: '111111111111.dkr.ecr.eu-west-1.amazonaws.com/service/test',
+        tag: 'sha-%s' % std.extVar('tag'),
+      }
+    },
+    job+: {
+      name: 'test',
+      podLabels+: {
+        team: 'devops'
+      },
+      container+: {
+        // Main application
+        name: 'test',
+
+        repository: '111111111111.dkr.ecr.eu-west-1.amazonaws.com/service/test',
+        tag: 'sha-%s' % std.extVar('tag'),
+      }
+    },
     ingress+: {
       host: '%(namespace)s.%(clusterDomain)s' % { namespace: s.namespace, clusterDomain: s.clusterDomain },
     },

--- a/tests/tanka/lib/letsbuilders/simple.libsonnet
+++ b/tests/tanka/lib/letsbuilders/simple.libsonnet
@@ -12,4 +12,9 @@ local lbKubernetes = import 'kubernetes/kubernetes.libsonnet';
       withIngress=true,
       ingressConfig=c.ingress,
     ),
+
+  statefulSet:
+    lbKubernetes.letsbuildServiceStatefulSet(c.statefulSet, withService=true),
+  job:
+    lbKubernetes.letsbuildJob(c.job),
 }


### PR DESCRIPTION
* adds basic validation with `kubeconform` - does not validate custom resources for now
* adds kubecost-required tags to buckets
* adds a `common` field to `config-skeleton.libsonnet` which holds configuration shared between `Deployment`, `StatefulSet` and `Job` resources
* adds metadata to Pods, as required by kubecost
* reduce default resource requests of `istio-proxy` to `10m`, as suggested by kubecost
* adds default ArgoCD sync annotations to `Jobs`. These are surplusly configured in each team repository