### PR TITLE
fix path generation for aproplan public api

### DIFF
--- a/kubernetes/config-skeleton.libsonnet
+++ b/kubernetes/config-skeleton.libsonnet
@@ -184,7 +184,7 @@
       },
     },
     aproplanAPI: {
-      name: 'aproplan-%s' % s.name,
+      name: s.name,
       host: 'aproplan-api.%(envDomain)s' % { envDomain: s.envDomain },
       // converting `host` to a list of hosts for backwards compatibility
       hosts: [self.host],

--- a/kubernetes/kubernetes.libsonnet
+++ b/kubernetes/kubernetes.libsonnet
@@ -296,7 +296,22 @@ local letsbuildServiceDeployment(
 
   publicApiIngress: if withPublicApi then publicApiIngressSpec(publicApiConfig),
 
-  aproplanApiIngress: if withAproplanApi then publicApiIngressSpec(aproplanApiConfig),
+  aproplanApiIngress: if withAproplanApi then publicApiIngressSpec(aproplanApiConfig) + {
+    metadata+: { name: 'aproplan-%s' % super.name },
+    spec+: {
+      rules: [
+        rule {
+          http+: {
+            paths: [
+              path { backend+: { service+: { name: 'aproplan-gateway' } } }
+              for path in super.paths
+            ],
+          },
+        }
+        for rule in super.rules
+      ],
+    },
+  },
 };
 
 local letsbuildServiceStatefulSet(statefulsetConfig, withService=true) = {


### PR DESCRIPTION
This will fix incorrect service name prefixing + forwarding requests to `aproplan-gateway` 