### PR TITLE
fix default scaling metric

### DIFF
--- a/kubernetes/config-skeleton.libsonnet
+++ b/kubernetes/config-skeleton.libsonnet
@@ -27,10 +27,9 @@
         minReplicas: 3,
         maxReplicas: 6,
         metrics: [{
-          type: 'ContainerResource',
-          containerResource: {
+          type: 'Resource',
+          resource: {
             name: 'cpu',
-            container: s.name,
             target: {
               type: 'Utilization',
               averageUtilization: 80,


### PR DESCRIPTION
container metrics require enabling the HPAContainerMetrics feature gate which is disabled in EKS