### PR TITLE
add support for multiple subpaths for one volume

### DIFF
--- a/kubernetes/kubernetes.libsonnet
+++ b/kubernetes/kubernetes.libsonnet
@@ -89,8 +89,8 @@ local containerSpecs(containersConfig) = [
     if std.objectHas(cont, 'port')
     then
       [
-      port.new(cont.name, cont.port)
-      + (if std.objectHas(cont, 'protocol') then port.withProtocol(cont.protocol) else {})
+        port.new(cont.name, cont.port)
+        + (if std.objectHas(cont, 'protocol') then port.withProtocol(cont.protocol) else {}),
       ]
     else if std.objectHas(cont, 'ports')
     then
@@ -249,7 +249,7 @@ local letsbuildServiceDeployment(
     ]);
 
     deployment.mapContainers(addMounts)
-    + deployment.mixin.spec.template.spec.withVolumesMixin(std.prune(
+    + deployment.mixin.spec.template.spec.withVolumesMixin(std.set(std.prune(
       [
         if std.objectHas(m, 'configMap') then volume.fromConfigMap(m.name, m.configMap.name, if std.objectHas(m.configMap, 'items') then m.configMap.items else []) else null
         for m in volumes
@@ -267,7 +267,7 @@ local letsbuildServiceDeployment(
         if std.objectHas(m, 'claim') then volume.fromPersistentVolumeClaim(m.name, m.claim.claimName) else null
         for m in volumes
       ]
-    )),
+    ), keyF=function(x) x.name)),
 
   deployment:
     deployment.new(dc.name, replicas=1, containers=containers)


### PR DESCRIPTION
with this change you can specify in the config

```jsonnet
deployment+: {
  volumes: [
    {
      name: 'config-volume',
      configMap: { name: s.common.name },
      path: '/etc/nginx/conf.d/default.conf',
      subPath: 'default.conf'
    },
    {
      name: 'config-volume',
      configMap: { name: s.common.name },
      path: '/usr/share/nginx/html/index.html',
      subPath: 'index.html'
    },
    {
      name: 'config-volume',
      configMap: { name: s.common.name },
      path: '/usr/share/nginx/html/images/LB-Aproplan.svg',
      subPath: 'LB-Aproplan.svg'
    },
  ],
}
```

and it will generate:
```yaml
volumeMounts:
- mountPath: /etc/nginx/conf.d/default.conf
  name: config-volume
  subPath: default.conf
- mountPath: /usr/share/nginx/html/index.html
  name: config-volume
  subPath: index.html
- mountPath: /usr/share/nginx/html/images/LB-Aproplan.svg
  name: config-volume
  subPath: LB-Aproplan.svg

```

```yaml
volumes:
- configMap:
    name: aproplan-maintenance-page
  name: config-volume
```
Without this change volumes would be duplicated.
